### PR TITLE
Enable domain-specific clients for UDA

### DIFF
--- a/helpers/datasets.py
+++ b/helpers/datasets.py
@@ -4,7 +4,35 @@ import numpy as np
 import torch
 import torchvision.transforms as transforms
 from torchvision import datasets, transforms
+from PIL import Image
 import random
+
+
+class ImageListDataset(torch.utils.data.Dataset):
+    """Dataset loaded from a text file with image paths and labels."""
+
+    def __init__(self, list_file, root="", transform=None):
+        self.root = root
+        self.transform = transform
+        self.images = []
+        self.labels = []
+        with open(list_file, "r") as f:
+            for line in f:
+                path, label = line.strip().split()
+                if root:
+                    path = os.path.join(root, path)
+                self.images.append(path)
+                self.labels.append(int(label))
+
+    def __len__(self):
+        return len(self.images)
+
+    def __getitem__(self, idx):
+        img = Image.open(self.images[idx]).convert("RGB")
+        label = self.labels[idx]
+        if self.transform:
+            img = self.transform(img)
+        return img, label
 
 
 
@@ -150,4 +178,49 @@ def partition_data(dataset, partition, beta=0.4, num_users=5):
             np.random.shuffle(idx_batch[j])
             net_dataidx_map[j] = idx_batch[j]
     train_data_cls_counts = record_net_data_stats(y_train, net_dataidx_map)
+    return train_dataset, test_dataset, net_dataidx_map, train_data_cls_counts
+
+
+def partition_data_by_domain(source_files, target_file=None, transform=None):
+    """Create datasets for domain adaptation where each domain is a client.
+
+    Args:
+        source_files (list[str]): list of txt files for source domains.
+        target_file (str, optional): txt file for target domain used as test.
+        transform: torchvision transform applied to all images.
+
+    Returns:
+        train_dataset (ConcatDataset): concatenation of all source domains.
+        test_dataset (Dataset): dataset for target domain.
+        net_dataidx_map (dict): indices for each client.
+        train_data_cls_counts (dict): class distribution for each client.
+    """
+    if transform is None:
+        transform = transforms.Compose([transforms.Resize(224),
+                                       transforms.CenterCrop(224),
+                                       transforms.ToTensor()])
+
+    train_datasets = []
+    net_dataidx_map = {}
+    train_data_cls_counts = {}
+    start = 0
+    for cid, f in enumerate(source_files):
+        ds = ImageListDataset(f, transform=transform)
+        train_datasets.append(ds)
+        idxs = list(range(start, start + len(ds)))
+        net_dataidx_map[cid] = idxs
+        labels = np.array(ds.labels)
+        uniq, cnt = np.unique(labels, return_counts=True)
+        train_data_cls_counts[cid] = {int(u): int(c) for u, c in zip(uniq, cnt)}
+        start += len(ds)
+
+    if len(train_datasets) == 1:
+        train_dataset = train_datasets[0]
+    else:
+        train_dataset = torch.utils.data.ConcatDataset(train_datasets)
+
+    test_dataset = None
+    if target_file is not None:
+        test_dataset = ImageListDataset(target_file, transform=transform)
+
     return train_dataset, test_dataset, net_dataidx_map, train_data_cls_counts

--- a/loop_df_fl.py
+++ b/loop_df_fl.py
@@ -12,7 +12,7 @@ import numpy as np
 from tqdm import tqdm
 import pdb
 
-from helpers.datasets import partition_data
+from helpers.datasets import partition_data, partition_data_by_domain
 from helpers.synthesizers import AdvSynthesizer
 from helpers.utils import get_dataset, average_weights, DatasetSplit, KLDiv, setup_seed, test
 from models.generator import Generator
@@ -86,6 +86,10 @@ def args_parser():
                         of dataset")
     parser.add_argument('--iid', type=int, default=1,
                         help='Default set to IID. Set to 0 for non-IID.')
+    parser.add_argument('--source_list', type=str, default=None,
+                        help='comma separated list of txt files for source domains')
+    parser.add_argument('--target_list', type=str, default=None,
+                        help='txt file for target domain (test set)')
 
     # Data Free
     parser.add_argument('--adv', default=0, type=float, help='scaling factor for adv loss')
@@ -205,8 +209,15 @@ if __name__ == '__main__':
 
     setup_seed(args.seed)
     # pdb.set_trace()
-    train_dataset, test_dataset, user_groups, traindata_cls_counts = partition_data(
-        args.dataset, args.partition, beta=args.beta, num_users=args.num_users)
+    if args.source_list is not None:
+        source_files = [s.strip() for s in args.source_list.split(',') if s.strip()]
+        target_file = args.target_list
+        args.num_users = len(source_files)
+        train_dataset, test_dataset, user_groups, traindata_cls_counts = partition_data_by_domain(
+            source_files, target_file)
+    else:
+        train_dataset, test_dataset, user_groups, traindata_cls_counts = partition_data(
+            args.dataset, args.partition, beta=args.beta, num_users=args.num_users)
 
     test_loader = torch.utils.data.DataLoader(test_dataset, batch_size=256,
                                               shuffle=False, num_workers=4)


### PR DESCRIPTION
## Summary
- add `ImageListDataset` and `partition_data_by_domain` helpers
- support lists of domain files in `loop_df_fl.py`
- use new partitioning when `--source_list` is provided

## Testing
- `python -m py_compile helpers/datasets.py loop_df_fl.py`

------
https://chatgpt.com/codex/tasks/task_e_686812d1f66483238b50271cf72d8518